### PR TITLE
add studio serve command

### DIFF
--- a/sites-config/ci.json
+++ b/sites-config/ci.json
@@ -37,6 +37,7 @@
     "buildCmd": "npm run build:local"
   },
   "livePreview": {
-    "serveSetupCmd": ":"
+    "serveSetupCmd": ":",
+    "serveCmd": "npm run studio"
   }
 }


### PR DESCRIPTION
The addition of this command should allow the user to run this Studio repo in the browser through code editor.